### PR TITLE
xio_connection: fin_request_timeout_work should be deleted only when …

### DIFF
--- a/src/common/xio_connection.c
+++ b/src/common/xio_connection.c
@@ -3102,8 +3102,6 @@ int xio_on_fin_ack_send_comp(struct xio_connection *connection,
 		xio_ctx_del_delayed_work(connection->ctx,
 				&connection->ka.timer);
 		xio_ctx_del_delayed_work(connection->ctx,
-				&connection->fin_req_timeout_work);
-		xio_ctx_del_delayed_work(connection->ctx,
 					 &connection->fin_ack_timeout_work);
 
 		connection->close_reason = XIO_E_SESSION_DISCONNECTED;


### PR DESCRIPTION
…XIO_FIN_RSP is received (in on_fin_ack_recv)