### PR TITLE
RFC: fix keepalive timeout handling

### DIFF
--- a/src/common/xio_connection.c
+++ b/src/common/xio_connection.c
@@ -181,7 +181,7 @@ char *xio_connection_state_str(enum xio_connection_state state)
 static inline int xio_is_connection_online(struct xio_connection *connection)
 {
 	    return connection &&
-		   connection->state == XIO_CONNECTION_STATE_ONLINE &&	   
+		   connection->state == XIO_CONNECTION_STATE_ONLINE &&
 		   connection->session &&
 		   connection->session->state == XIO_SESSION_STATE_ONLINE;
 }
@@ -1580,10 +1580,10 @@ int xio_connection_detach_of_tasks(struct xio_connection *connection)
 		return 0;
 
 	pool = connection->ctx->primary_tasks_pool[XIO_PROTO_RDMA];
-	xio_tasks_pool_detach_connection(pool, connection); 
+	xio_tasks_pool_detach_connection(pool, connection);
 
 	pool = connection->ctx->primary_tasks_pool[XIO_PROTO_TCP];
-	xio_tasks_pool_detach_connection(pool, connection); 
+	xio_tasks_pool_detach_connection(pool, connection);
 
 	return 0;
 }
@@ -1604,7 +1604,7 @@ static void xio_connection_post_close(void *_connection)
 
 	xio_ctx_del_delayed_work(connection->ctx,
 				 &connection->fin_req_timeout_work);
-	
+
 	xio_ctx_del_delayed_work(connection->ctx,
 				 &connection->fin_ack_timeout_work);
 
@@ -1715,7 +1715,7 @@ int xio_release_response(struct xio_msg *msg)
 		connection = task->connection;
 		if (unlikely(!connection)) {
 			ERROR_LOG("%s failed. response release after " \
-				  "connection destroy is forbidden\n", 
+				  "connection destroy is forbidden\n",
 				  __func__);
 			xio_set_error(EINVAL);
 			return -1;
@@ -1954,7 +1954,7 @@ static void xio_fin_req_timeout(void *conn)
 static void xio_fin_ack_timeout(void *conn)
 {
 	struct xio_connection *connection = (struct xio_connection *)conn;
-	
+
 	ERROR_LOG("fin ack timeout. session:%p, connection:%p\n",
 		  connection->session, connection);
 
@@ -2351,7 +2351,7 @@ int xio_modify_connection(struct xio_connection *connection,
         if (test_bits(XIO_CONNECTION_ATTR_DISCONNECT_TIMEOUT, &attr_mask)) {
                 if (attr->disconnect_timeout_secs)
 			connection->disconnect_timeout = attr->disconnect_timeout_secs * 1000;
-		else 
+		else
 			connection->disconnect_timeout = XIO_DEF_CONNECTION_TIMEOUT;
         }
 		/*
@@ -2534,7 +2534,7 @@ static void xio_connection_post_destroy(struct kref *kref)
                 }
                 tmp_connection = session->lead_connection;
 		session->lead_connection = NULL;
-	
+
 		DEBUG_LOG("xio_connection_post_destroy: lead connection is closed. " \
 			  "session:%p, connection:%p nexus:%p nr:%d\n",
 			  session, connection, connection->nexus, session->connections_nr);
@@ -2575,7 +2575,7 @@ static void xio_connection_post_destroy(struct kref *kref)
 	}
 	DEBUG_LOG("xio_connection_post_destroy init session teardown. " \
 		  "session:%p, connection:%p, nr:%d, disable_teardown:%d, " \
-		  "destroy_session:%d\n", 
+		  "destroy_session:%d\n",
 		  session, connection,
 		  session->connections_nr,
 		  session->disable_teardown,
@@ -2707,7 +2707,7 @@ int xio_connection_disconnected(struct xio_connection *connection)
 	int close = 0;
 
 	DEBUG_LOG("xio_connection_disconnected: connection:%p, state:%s\n",
-		  connection, 
+		  connection,
 		  xio_connection_state_str((enum xio_connection_state)
 					   connection->state));
 
@@ -2749,7 +2749,7 @@ int xio_connection_disconnected(struct xio_connection *connection)
 		    connection->session->lead_connection->nexus ==
 		    connection->nexus) {
 			DEBUG_LOG("xio_connection_disconnected: null " \
-				  "the lead connection. connection:%p\n", 
+				  "the lead connection. connection:%p\n",
 				  connection);
 			connection->session->lead_connection = NULL;
 			close = 1;
@@ -2758,7 +2758,7 @@ int xio_connection_disconnected(struct xio_connection *connection)
 		    connection->session->redir_connection->nexus ==
 		    connection->nexus) {
 			DEBUG_LOG("xio_connection_disconnected: null " \
-				  "the redir connection connection:%p\n", 
+				  "the redir connection connection:%p\n",
 				  connection);
 			connection->session->redir_connection = NULL;
 			close = 1;
@@ -2766,7 +2766,7 @@ int xio_connection_disconnected(struct xio_connection *connection)
 		/* free nexus and tasks pools */
 		if (close) {
 			DEBUG_LOG("xio_connection_disconnected: nexus " \
-				  "close. connection:%p nexus:%p\n", 
+				  "close. connection:%p nexus:%p\n",
 				  connection, connection->nexus);
 			xio_connection_flush_tasks(connection);
 			xio_connection_nexus_safe_close(connection,
@@ -3576,7 +3576,7 @@ void xio_connection_keepalive_intvl(void *_connection)
 
 	xio_ctx_del_delayed_work(connection->ctx,
 				 &connection->ka.timer);
-		
+
 	if (connection->disconnecting && (!g_options.reconnect))
 		return;
 
@@ -3601,6 +3601,9 @@ void xio_connection_keepalive_intvl(void *_connection)
 		ERROR_LOG("connection keepalive timeout. connection:%p probes:[%d]\n",
 			  connection, connection->ka.probes);
 		connection->ka.probes = 0;
+
+		/* notify the transport via the nexus */
+		xio_nexus_keepalive_timeout(connection->nexus);
 
 		/* notify the application of connection error */
 		xio_session_notify_connection_error(

--- a/src/common/xio_nexus.c
+++ b/src/common/xio_nexus.c
@@ -2802,3 +2802,14 @@ void xio_nexus_set_server(struct xio_nexus *nexus, struct xio_server *server)
 	if (server)
 		xio_server_reg_observer(server, &nexus->srv_observer);
 }
+
+/*---------------------------------------------------------------------------*/
+/* xio_nexus_keepalive_timeout						     */
+/*---------------------------------------------------------------------------*/
+void xio_nexus_keepalive_timeout(struct xio_nexus *nexus)
+{
+	if (nexus->transport->keepalive_timeout)
+		nexus->transport->keepalive_timeout(nexus->transport_hndl);
+	else
+		ERROR_LOG("transport cannot be notified of keepalive timeout");
+}

--- a/src/common/xio_nexus.h
+++ b/src/common/xio_nexus.h
@@ -384,6 +384,11 @@ int xio_nexus_query(struct xio_nexus *nexus,
 		    struct xio_nexus_attr *attr,
 		    int attr_mask);
 
+/*---------------------------------------------------------------------------*/
+/* xio_nexus_keepalive_timeout						     */
+/*---------------------------------------------------------------------------*/
+void xio_nexus_keepalive_timeout(struct xio_nexus *nexus);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/xio_session.c
+++ b/src/common/xio_session.c
@@ -1380,8 +1380,9 @@ int xio_on_nexus_error(struct xio_session *session, struct xio_nexus *nexus,
 		break;
 	default:
 		connection = xio_session_find_connection(session, nexus);
-		xio_connection_error_event(connection,
-					   event_data->error.reason);
+		if (connection)
+			xio_connection_error_event(connection,
+						   event_data->error.reason);
 		break;
 	}
 
@@ -2212,4 +2213,3 @@ void xio_session_init_teardown(struct xio_session *session,
 				xio_session_pre_teardown,
 				&session->teardown_work);
 }
-

--- a/src/common/xio_transport.h
+++ b/src/common/xio_transport.h
@@ -278,6 +278,8 @@ struct xio_transport {
 			 struct xio_transport_attr *attr,
 			 int attr_mask);
 
+	void	(*keepalive_timeout)(struct xio_transport_base *trans_hndl);
+
 	struct list_head transports_list_entry;
 };
 

--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -193,6 +193,8 @@ int xio_tcp_single_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
 	if (retval) {
 		ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
 			  tcp_hndl, tcp_hndl->sock.cfd);
+	} else {
+		tcp_hndl->in_epoll[0] = 0;
 	}
 
 	return retval;
@@ -212,7 +214,9 @@ int xio_tcp_dual_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
                 if (retval1) {
                         ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
                                   tcp_hndl, tcp_hndl->sock.cfd);
-                }
+                } else {
+			tcp_hndl->in_epoll[0] = 0;
+		}
         }
 	/* remove from epoll */
         if (tcp_hndl->in_epoll[1]) {
@@ -222,7 +226,9 @@ int xio_tcp_dual_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
                 if (retval2) {
                         ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
                                   tcp_hndl, tcp_hndl->sock.dfd);
-                }
+                }  else {
+			tcp_hndl->in_epoll[1] = 0;
+		}
         }
 
 	return retval1 | retval2;

--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -2644,6 +2644,24 @@ static int xio_tcp_dup2(struct xio_transport_base *old_trans_hndl,
 }
 
 /*---------------------------------------------------------------------------*/
+/* xio_tcp_keepalive_timeout                                                 */
+/*---------------------------------------------------------------------------*/
+static void xio_tcp_keepalive_timeout(struct xio_transport_base *trans_hndl)
+{
+	struct xio_tcp_transport *tcp_hndl =
+		(struct xio_tcp_transport *)trans_hndl;
+
+	xio_context_disable_event(&tcp_hndl->flush_tx_event);
+	xio_context_disable_event(&tcp_hndl->ctl_rx_event);
+
+	if (tcp_hndl->sock.ops->del_ev_handlers)
+		tcp_hndl->sock.ops->del_ev_handlers(tcp_hndl);
+
+	xio_transport_notify_observer_error(trans_hndl,
+					    XIO_E_TIMEOUT);
+}
+
+/*---------------------------------------------------------------------------*/
 static void init_single_sock_ops(void)
 {
 	single_sock_ops.open = xio_tcp_single_sock_create;
@@ -2699,6 +2717,8 @@ static void init_xio_tcp_transport(void)
 	xio_tcp_transport.get_opt = xio_tcp_get_opt;
 	xio_tcp_transport.cancel_req = xio_tcp_cancel_req;
 	xio_tcp_transport.cancel_rsp = xio_tcp_cancel_rsp;
+	xio_tcp_transport.keepalive_timeout = xio_tcp_keepalive_timeout;
+
 	xio_tcp_transport.get_pools_setup_ops = xio_tcp_get_pools_ops;
 	xio_tcp_transport.set_pools_cls = xio_tcp_set_pools_cls;
 


### PR DESCRIPTION
We've been running into issues with the keepalive mechanism: tests with error injection (packet loss with `netem`) brought up use-after-free problems, which basically boil down to:
* keepalive time out leads to the application's `on_msg_error` callback getting invoked, prompting the application code to release per-message resources (e.g. data buffers)
* the data connection is actually still alive and e.g. data is ready to be received into buffers that were just released
.

Based on the above analysis, the idea is to notify the transport layer of the keepalive timeout which in turn will stop further processing of events and notify its observers (only implemented for TCP at the moment).
Does that approach make sense or are we overlooking something? Is there a better way to address this?