### PR TITLE
src/usr/xio: Change CPU frequency reading to fail only with > 2% diff

### DIFF
--- a/src/usr/xio/get_clock.c
+++ b/src/usr/xio/get_clock.c
@@ -141,6 +141,7 @@ static double proc_get_cpu_mhz(int no_cpu_freq_fail)
 	FILE *f;
 	char buf[256];
 	double mhz = 0.0;
+	double delta;
 
 	f = fopen("/proc/cpuinfo", "r");
 	if (!f)
@@ -166,7 +167,8 @@ static double proc_get_cpu_mhz(int no_cpu_freq_fail)
 			mhz = m;
 			continue;
 		}
-		if (mhz != m) {
+		delta = mhz > m ? mhz - m : m - mhz;
+		if (delta / mhz > 0.02) {
 			fprintf(stderr, "Conflicting CPU frequency values" \
 				" detected: %lf != %lf\n", mhz, m);
 			if (no_cpu_freq_fail)
@@ -244,7 +246,7 @@ double get_cpu_mhz(int no_cpu_freq_fail)
 		return 0;
 
 	delta = proc > sample ? proc - sample : sample - proc;
-	if (delta / proc > 0.01) {
+	if (delta / proc > 0.02) {
 			fprintf(stderr, "Warning: measured timestamp" \
 				" frequency %g differs from nominal %g MHz\n",
 					sample, proc);


### PR DESCRIPTION
Signed-off-by: Yan Burman <yanburman@users.noreply.github.com>