### PR TITLE
RFC: address "unknown TX stage" errors

### DIFF
--- a/src/usr/linux/list.h
+++ b/src/usr/linux/list.h
@@ -413,6 +413,15 @@ static inline void list_splice_tail_init(struct list_head *list,
 	list_entry((pos)->member.next, typeof(*(pos)), member)
 
 /**
+ * list_next_entry_or_null - get the next element in list unless it's the head
+ * @head:       the list head
+ * @pos:	cursor: pointer to the current entry
+ * @member:	the name of the list_head within the entry.
+ */
+#define list_next_entry_or_null(head, pos, member)                      \
+	(((pos)->member.next == head) ? NULL : list_next_entry(pos, member))
+
+/**
  * list_prev_entry - get the prev element in list
  * @pos:	the type * to cursor
  * @member:	the name of the list_struct within the struct.
@@ -772,4 +781,3 @@ static inline void hlist_move_list(struct hlist_head *old,
 
 
 #endif
-

--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -188,8 +188,6 @@ static int xio_tcp_flush_all_tasks(struct xio_tcp_transport *tcp_hndl)
 		xio_tasks_list_flush(&tcp_hndl->rx_list);
 	}
 
-	tcp_hndl->tx_ready_tasks_num = 0;
-
 	return 0;
 }
 
@@ -907,7 +905,7 @@ struct xio_tcp_transport *xio_tcp_transport_create(
 	tcp_hndl->tmp_rx_buf_cur	= NULL;
 	tcp_hndl->tmp_rx_buf_len	= 0;
 
-	tcp_hndl->tx_ready_tasks_num = 0;
+	tcp_hndl->_pad = 0;
 	tcp_hndl->tx_comp_cnt = 0;
 
 	memset(&tcp_hndl->tmp_work, 0, sizeof(struct xio_tcp_work_req));

--- a/src/usr/transport/tcp/xio_tcp_transport.h
+++ b/src/usr/transport/tcp/xio_tcp_transport.h
@@ -321,8 +321,8 @@ struct xio_tcp_transport {
 
 	/* tx parameters */
 	size_t				max_inline_buf_sz;
-
-	int				tx_ready_tasks_num;
+	/* this used to be `tx_ready_tasks_num` - keeping it to satisfy `-Werror=padded` */
+	int				_pad;
 
 	uint16_t			tx_comp_cnt;
 


### PR DESCRIPTION
This PR aims to address "unknown TX stage" errors observed in the TCP data path after network problems, which is not easily reproducible. Eventually inspection of such a case with gdb succeeded and showed that `tx_ready_tasks_num` and `tx_ready_list` of `struct xio_tcp_transport` were out of sync. The reason for that isn't clear, but this PR takes the approach of preventing this altogether by removing the double bookkeeping and relying solely on `tx_ready_list` as the source of truth.
It also emerged that there are uses of `list_first_entry_or_null` on a list *member* (instead of the list *head*) in order to find the next element in the list if any. This will never return `NULL` but instead misinterpret the list head.

This hasn't seen much testing yet; I'm posting it as RFC to discuss if this strategy is valid.